### PR TITLE
Pass the timeout to the genserver call

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ by adding `socket_drano` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:socket_drano, "~> 0.3.0"}
+    {:socket_drano, "~> 0.3.1"}
   ]
 end
 ```

--- a/lib/socket_drano.ex
+++ b/lib/socket_drano.ex
@@ -34,6 +34,9 @@ defmodule SocketDrano do
   If you run into issues in your test or development environment, you can set the `shutdown_delay`
   to a low value, such as `0` in non-production environments.
 
+  If you are using a shell script to start your application, be sure that it isn't trapping
+  OS signals. [Sigterm Propagation](http://veithen.io/2014/11/16/sigterm-propagation.html)
+
   ## Options
 
   The following options can be given to the child spec:
@@ -128,7 +131,7 @@ defmodule SocketDrano do
 
     :drano_signal_handler.setup(
       shutdown_delay: opts[:shutdown_delay],
-      callback: {__MODULE__, :start_draining, []}
+      callback: {__MODULE__, :start_draining, [opts[:shutdown_delay]]}
     )
 
     Process.flag(:trap_exit, true)
@@ -207,8 +210,8 @@ defmodule SocketDrano do
     {:reply, :ok, state}
   end
 
-  def start_draining do
-    GenServer.call(__MODULE__, :start_draining)
+  def start_draining(timeout \\ 5000) do
+    GenServer.call(__MODULE__, :start_draining, timeout)
   end
 
   def draining? do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SocketDrano.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
 
   def project do
     [


### PR DESCRIPTION
The call to `start_draining/0` would timeout if the shutdown delay was greater than 5s due to the default timeout on genserver calls. This matches the timeout on that call to the shutdown delay.