### PR TITLE
The child spec had the wrong args in callback MFA

### DIFF
--- a/lib/socket_drano.ex
+++ b/lib/socket_drano.ex
@@ -131,7 +131,7 @@ defmodule SocketDrano do
 
     :drano_signal_handler.setup(
       shutdown_delay: opts[:shutdown_delay],
-      callback: {__MODULE__, :start_draining, [opts[:shutdown_delay]]}
+      callback: {__MODULE__, :start_draining, []}
     )
 
     Process.flag(:trap_exit, true)
@@ -219,7 +219,11 @@ defmodule SocketDrano do
   end
 
   def socket_count do
-    GenServer.call(__MODULE__, :socket_count)
+    if GenServer.whereis(__MODULE__) do
+      GenServer.call(__MODULE__, :socket_count)
+    else
+      :not_running
+    end
   end
 
   def handle_event(

--- a/test/socket_drano_test.exs
+++ b/test/socket_drano_test.exs
@@ -68,6 +68,8 @@ defmodule SocketDranoTest do
       %{pid: self()}
     )
 
+    assert SocketDrano.socket_count() == :not_running
+
     spec = SocketDrano.child_spec(refs: [], shutdown_delay: 10_000)
     start_supervised!(spec)
     disconnects_pid = spawn_link(fn -> disconnects([]) end)


### PR DESCRIPTION
`start_draining` is zero arity and the callback had an arg. This was a remnant from prior to storing the strategy in state.