### PR TITLE
perf: use function captures as event handler

### DIFF
--- a/lib/socket_drano.ex
+++ b/lib/socket_drano.ex
@@ -126,7 +126,13 @@ defmodule SocketDrano do
     opts = ensure_opts(opts)
     :ok = validate_opts!(opts)
 
-    :telemetry.attach(:drano_channel_connect, [:phoenix, :channel_joined], &handle_event/4, %{})
+    :telemetry.attach(
+      :drano_channel_connect,
+      [:phoenix, :channel_joined],
+      &__MODULE__.handle_event/4,
+      %{}
+    )
+
     :persistent_term.put({:socket_drano, :draining}, false)
 
     :drano_signal_handler.setup(


### PR DESCRIPTION
Use function captures as event handlers to achieve the best performance.

See for more info: https://hexdocs.pm/telemetry/telemetry.html#attach/4